### PR TITLE
fix: drop Guava dependency from SchemesTreeBuilderTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,13 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludeJUnit5Engines>spock</excludeJUnit5Engines>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.4.0</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent-pom</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>liquibase-cdi</artifactId>
@@ -82,15 +82,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludedEngines>
-                        <excludedEngine>spock</excludedEngine>
-                    </excludedEngines>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,15 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludedEngines>
+                        <excludedEngine>spock</excludedEngine>
+                    </excludedEngines>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.4.0</version>
                 <executions>

--- a/src/test/java/liquibase/integration/cdi/SchemesTreeBuilderTest.java
+++ b/src/test/java/liquibase/integration/cdi/SchemesTreeBuilderTest.java
@@ -1,6 +1,5 @@
 package liquibase.integration.cdi;
 
-import com.google.common.base.Strings;
 import liquibase.integration.cdi.annotations.LiquibaseSchema;
 import liquibase.integration.cdi.exceptions.CyclicDependencyException;
 import liquibase.integration.cdi.exceptions.DependencyNotFoundException;
@@ -53,7 +52,7 @@ public class SchemesTreeBuilderTest {
         Collection<LiquibaseSchema> previous = new ArrayList<LiquibaseSchema>(resolved.size());
 
         for (LiquibaseSchema liquibaseSchema : resolved) {
-            if (!Strings.isNullOrEmpty(liquibaseSchema.depends())) {
+            if (liquibaseSchema.depends() != null && !liquibaseSchema.depends().isEmpty()) {
                 assertFalse(isDependencyMissed(liquibaseSchema, previous));
             }
             previous.add(liquibaseSchema);
@@ -78,7 +77,7 @@ public class SchemesTreeBuilderTest {
 
         Collection<LiquibaseSchema> previous = new ArrayList<LiquibaseSchema>(resolved.size());
         for (LiquibaseSchema liquibaseSchema : resolved) {
-            if (!Strings.isNullOrEmpty(liquibaseSchema.depends())) {
+            if (liquibaseSchema.depends() != null && !liquibaseSchema.depends().isEmpty()) {
                 assertFalse(isDependencyMissed(liquibaseSchema, previous));
             }
             previous.add(liquibaseSchema);


### PR DESCRIPTION
## Summary

- Remove the `com.google.common.base.Strings` import from `SchemesTreeBuilderTest.java`.
- Replace the two `Strings.isNullOrEmpty(s)` call sites with `s == null || s.isEmpty()`.

## Why

`testCompile` has been failing on every dependabot PR (#41 / #42 / #43) with:

```
package com.google.common.base does not exist
cannot find symbol: variable Strings
```

The test imports Guava's `Strings.isNullOrEmpty`, but Guava is not declared in `pom.xml`. It was arriving transitively through `jaxb-runtime 2.3.3`. Dependabot PR #25 (merged 2026-03-06) bumped `jaxb-runtime` to `4.x`, which no longer pulls Guava. Tests stopped compiling that day.

The breakage didn't show up on `main` because the build/test workflow only runs on `pull_request_target` (not on push to main). Every open PR has been rebuilding against a latently-broken `main` and hitting the same compile error.

## Test plan

- [ ] `mvn test` (or wait for CI on this PR) — `SchemesTreeBuilderTest` should compile and all 7 tests pass
- [ ] After merge, recreate dependabot PRs #41 / #42 / #43 and confirm their builds go green